### PR TITLE
Use mojular functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
 
 var importPaths = [];
-importPaths.push(require('mojular-govuk-elements').getPaths('sass'));
-importPaths.push(require('mojular-moj-elements').getPaths('sass'));
+importPaths.push(require('mojular-govuk-elements').sassPaths);
+importPaths.push(require('mojular-moj-elements').sassPaths);
 
 gulp.task('sass', function() {
   var result = gulp.src('path/to/your/local/styles/**/*.scss')

--- a/index.js
+++ b/index.js
@@ -1,26 +1,5 @@
-var packageMeta = require('./package.json');
-var util = require('util');
-
-function prefixPaths(paths) {
-  return paths.map(function(path) {
-    return util.format('node_modules/%s/%s', packageMeta.name, path);
-  });
-}
+var mojular = require('mojular');
 
 module.exports = {
-  getPaths: function(key) {
-    var paths = packageMeta.paths;
-    if(paths) {
-      Object.keys(paths).forEach(function(k) {
-        paths[k] = prefixPaths(paths[k]);
-      });
-    } else {
-      paths = [];
-    }
-    if(!paths[key]) {
-      throw new Error('`' + key + '` can’t be found in paths');
-    }
-
-    return paths[key];
-  }
+  sassPaths: mojular.getSassPaths(require('./package.json'))
 };

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "mojular": "mojular/mojular",
     "mojular-govuk-elements": "mojular/govuk-elements"
   },
-  "devDependencies": {
-    "json-loader": "^0.5.3"
-  },
   "paths": {
     "sass": [
       "node_modules/mojular-govuk-elements/assets/sass/",


### PR DESCRIPTION
Use Mojular as dependency to reduce code repetition to get Sass paths.

Depends on [mojular#3](https://github.com/mojular/mojular/pull/3).
